### PR TITLE
0.1.0rc6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sd-mecha"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 description = "State dict recipe merger"
 readme = "README.md"
 authors = [{ name = "ljleb" }]

--- a/sd_mecha/conversion.py
+++ b/sd_mecha/conversion.py
@@ -32,6 +32,7 @@ def convert(recipe: RecipeNodeOrValue, config: str | ModelConfig | RecipeNode, m
         ValueError:
             If no conversion path is found.
     """
+    model_dirs = list(model_dirs)
     all_converters = merge_methods.get_all_converters()
     converter_paths: Dict[str, List[Tuple[str, Any]]] = {}
     for converter in all_converters:

--- a/sd_mecha/merging.py
+++ b/sd_mecha/merging.py
@@ -351,7 +351,7 @@ def open_input_dicts(
     empty_cuda_cache: bool = False,
 ):
     try:
-        recipe.accept(LoadInputDictsVisitor(model_dirs, buffer_size_per_dict, omit_extra_keys, check_mandatory_keys))
+        recipe.accept(LoadInputDictsVisitor(list(model_dirs), buffer_size_per_dict, omit_extra_keys, check_mandatory_keys))
         yield recipe
     finally:
         recipe.accept(CloseInputDictsVisitor())


### PR DESCRIPTION
Python iterables are not necessarily iterable more than once. Some parts of the code need to iterate over model_dirs more than once, so we need to make a copy of the argument (or restrict the parameter type to something like Sequence)