### PR TITLE
Add Isotropic Merge (Iso-C only)

### DIFF
--- a/sd_mecha/__init__.py
+++ b/sd_mecha/__init__.py
@@ -30,6 +30,7 @@ from sd_mecha.extensions.builtin.merge_methods import (
     omit_component,
     exchange_ema,
     isotropic,
+    isotropic_overrided,
 )
 from .merge_method_wrappers import (
     add_difference,

--- a/sd_mecha/__init__.py
+++ b/sd_mecha/__init__.py
@@ -29,6 +29,7 @@ from sd_mecha.extensions.builtin.merge_methods import (
     pick_component,
     omit_component,
     exchange_ema,
+    isotropic,
 )
 from .merge_method_wrappers import (
     add_difference,

--- a/sd_mecha/extensions/builtin/merge_methods/__init__.py
+++ b/sd_mecha/extensions/builtin/merge_methods/__init__.py
@@ -26,7 +26,7 @@ from .logistics import (
     cast_dtype_map_reversed,
 )
 from .slicing import tensor_sum, top_k_tensor_sum
-from .svd import rotate, truncate_rank, isotropic
+from .svd import rotate, truncate_rank, isotropic, isotropic_overrided
 from .ties_sum import (
     ties_sum_with_dropout,
     ties_sum,

--- a/sd_mecha/extensions/builtin/merge_methods/__init__.py
+++ b/sd_mecha/extensions/builtin/merge_methods/__init__.py
@@ -26,7 +26,7 @@ from .logistics import (
     cast_dtype_map_reversed,
 )
 from .slicing import tensor_sum, top_k_tensor_sum
-from .svd import rotate, truncate_rank
+from .svd import rotate, truncate_rank, isotropic
 from .ties_sum import (
     ties_sum_with_dropout,
     ties_sum,

--- a/sd_mecha/extensions/builtin/merge_methods/svd.py
+++ b/sd_mecha/extensions/builtin/merge_methods/svd.py
@@ -146,11 +146,13 @@ def truncate_rank(
 
 # https://arxiv.org/abs/2502.04959
 # Focus on Iso-C until I have idea to write Iso-CTS.
+# z_cof: 0 = iso-c, 1 = not applied, recommended 0.8 or 2.0, by "SVD image reconstruction test"
 # apply_exp: Use exponential mean instead of arithmetic mean. Proposed by ljleb.
 # apply_high_dim: Apply SVD on tensors with dim > 2. Paper apply for dim==2. SVD does not accept dim < 2.
 @merge_method
 def isotropic(
     *deltas: Parameter(Tensor, "delta"),
+    z_cof: Parameter(float) = 0.0,
     apply_exp: Parameter(bool) = False,
     apply_high_dim: Parameter(bool) = False,
 ) -> Return(Tensor, "delta"):
@@ -171,8 +173,14 @@ def isotropic(
     # Can it be any kind of mean?
     S_mean = S_ta.log().mean().exp() if apply_exp else S_ta.mean()
 
+    S_Var = S_ta.var()
+
+    Z_ta = (S_ta - S_mean) / S_Var
+
+    S_z = (Z_ta * z_cof) * S_Var + S_mean
+
     # Follow paper's implementation
-    S_bar = torch.ones_like(S_ta) * S_mean
+    S_bar = torch.ones_like(S_ta) * S_z
 
     d_Iso_c = torch.linalg.multi_dot((U_ta, torch.diag(S_bar), Vh_ta)) 
 
@@ -181,11 +189,13 @@ def isotropic(
 
 # https://arxiv.org/abs/2502.04959
 # Instead of sum of vectors, we feed the merged vector.
+# z_cof: 0 = iso-c, 1 = not applied, recommended 0.8 or 2.0, by "SVD image reconstruction test"
 # apply_exp: Use exponential mean instead of arithmetic mean. Proposed by ljleb.
 # apply_high_dim: Apply SVD on tensors with dim > 2. Paper apply for dim==2. SVD does not accept dim < 2.
 @merge_method
 def isotropic_overrided(
     d_ta: Parameter(Tensor, "delta"),
+    z_cof: Parameter(float) = 0.0,
     apply_exp: Parameter(bool) = False,
     apply_high_dim: Parameter(bool) = False,
 ) -> Return(Tensor, "delta"):
@@ -206,8 +216,14 @@ def isotropic_overrided(
     # Can it be any kind of mean?
     S_mean = S_ta.log().mean().exp() if apply_exp else S_ta.mean()
 
+    S_Var = S_ta.var()
+
+    Z_ta = (S_ta - S_mean) / S_Var
+
+    S_z = (Z_ta * z_cof) * S_Var + S_mean
+
     # Follow paper's implementation
-    S_bar = torch.ones_like(S_ta) * S_mean
+    S_bar = torch.ones_like(S_ta) * S_z
 
     d_Iso_c = torch.linalg.multi_dot((U_ta, torch.diag(S_bar), Vh_ta)) 
 

--- a/sd_mecha/merge_method_wrappers.py
+++ b/sd_mecha/merge_method_wrappers.py
@@ -11,6 +11,7 @@ from sd_mecha.extensions.builtin.merge_methods import (
     clamp,
     model_stock,
     isotropic,
+    isotropic_overrided,
 )
 
 
@@ -331,8 +332,7 @@ def ties_with_dare(
 
     if apply_isotropic:
         # This stage will stress a lot.
-        _, S_tmp = isotropic(*deltas)
-        S_bar = S_tmp
+        S_bar = isotropic(*deltas, return_sbar=True)
 
     # $$ \tilde{\delta}^{t_k} $$
     res = ties_sum_with_dropout(
@@ -352,13 +352,9 @@ def ties_with_dare(
     )
 
     if S_bar:
-        d_ta = torch.clone(res)
-
-        # S_ta will be different from S_bar
-        U_ta, _, Vh_ta = torch.linalg.svd(d_ta)
-
         # Rearranged for notation $$ \sigma U V^T $$
-        res = S_bar * U_ta @ Vh_ta
+        r_tmp = isotropic_overrided(res, S_bar)
+        res = r_tmp
 
     # $$ \theta_M = \theta_{PRE} + \lambda \cdot \Sigma_{k=1}^{K} \tilde{\delta}^{t_k} $$
     return merge_methods.add_difference(base, res, alpha=alpha)

--- a/sd_mecha/merge_method_wrappers.py
+++ b/sd_mecha/merge_method_wrappers.py
@@ -165,39 +165,6 @@ def add_difference_ties_extended(
     )
 
 
-# https://arxiv.org/abs/2502.04959
-def add_difference_isotropic(
-    base: RecipeNodeOrValue,
-    *models: RecipeNodeOrValue,
-    alpha: Parameter(Tensor) = 1.0,
-    apply_exp: Parameter(bool) = False,
-    apply_high_dim: Parameter(bool) = False,
-) -> recipe_nodes.RecipeNode:
-    # $$ \theta_{t=1}^T $$
-    base = value_to_node(base)
-    models = tuple(value_to_node(model) for model in models)
-
-    # Create task vectors.
-    # $$ \Delta_t $$
-    models = tuple(
-        subtract(model, base)
-        if model.merge_space == "weight" else
-        model
-        for model in models
-    )
-
-    res, _ = isotropic(
-        *models, apply_exp=apply_exp, apply_high_dim=apply_high_dim
-    )
-
-    # Obtain merged checkpoint
-
-    # $$ \theta_{0}^{(l)} + \alpha * \Delta_{Iso_C}^{(l)} $$
-    return add_difference(
-        base, res,
-        alpha=alpha,
-    )
-
 def copy_region(
     a: RecipeNodeOrValue, b: RecipeNodeOrValue, c: Optional[RecipeNodeOrValue] = None, *,
     width: Parameter(float) = 1.0,
@@ -316,6 +283,7 @@ def ties_with_dare(
     cos_eps: Parameter(float) = 1e-6,
     apply_median: Parameter(bool) = False,
     apply_isotropic: Parameter(bool) = False,
+    z_cof: Parameter(float) = 0.0,
     apply_exp: Parameter(bool) = False,
     apply_high_dim: Parameter(bool) = False,
     eps: Parameter(float) = 1e-6,
@@ -351,7 +319,7 @@ def ties_with_dare(
 
     if apply_isotropic:
         # This stage will stress a lot.
-        res = isotropic_overrided(res, apply_exp=apply_exp, apply_high_dim=apply_high_dim)
+        res = isotropic_overrided(res, z_cof=z_cof, apply_exp=apply_exp, apply_high_dim=apply_high_dim)
 
     # $$ \theta_M = \theta_{PRE} + \lambda \cdot \Sigma_{k=1}^{K} \tilde{\delta}^{t_k} $$
     return merge_methods.add_difference(base, res, alpha=alpha)

--- a/sd_mecha/merge_method_wrappers.py
+++ b/sd_mecha/merge_method_wrappers.py
@@ -274,7 +274,6 @@ def ties_with_dare(
         *deltas,
         della_eps=della_eps,
         probability=probability,
-        della_eps=della_eps,
         rescale=rescale,
         k=k,
         vote_sgn=vote_sgn,

--- a/sd_mecha/merging.py
+++ b/sd_mecha/merging.py
@@ -310,6 +310,7 @@ def _track_output(fn, output, key, check_finite: bool):
 
                 if not all_finite:
                     logging.warning(f"there are non finite values in key '{key}'")
+                    res = torch.nan_to_num(res)
 
             output[key] = res
         except StateDictKeyError as k:

--- a/tests/merge_methods/test_isotropic.py
+++ b/tests/merge_methods/test_isotropic.py
@@ -39,7 +39,7 @@ def test_isotropic():
     apply_exp_1 = False
     apply_high_dim_1 = False
 
-    Iso_c = sd_mecha.isotropic.__wrapped__(*models, apply_exp=apply_exp_1, apply_high_dim=apply_high_dim_1)
+    Iso_c = sd_mecha.isotropic.__wrapped__(*models, z_cof=0.0, apply_exp=apply_exp_1, apply_high_dim=apply_high_dim_1)
     #print(Iso_c)
     assert torch.allclose(Iso_c, expected, atol=0.0001)
 

--- a/tests/merge_methods/test_isotropic.py
+++ b/tests/merge_methods/test_isotropic.py
@@ -1,0 +1,42 @@
+import torch
+import sd_mecha
+
+def test_isotropic():
+    models = [
+        torch.tensor([
+            [ 3.,  4.,  1., -2.],
+            [ 2.,  1., -4.,  3.],
+            [-1.,  2.,  3.,  4.],
+            [ 4., -3.,  2.,  1.],
+        ]),
+        torch.tensor([
+            [-1.,  3.,  4.,  2.],
+            [ 4.,  2., -3.,  1.],
+            [ 3., -1.,  2.,  4.],
+            [ 2.,  4.,  1., -3.],
+        ]),
+        torch.tensor([
+            [-1.,  3.,  2.,  0.],
+            [ 3.,  0.,  2.,  1.],
+            [-1.,  3.,  1.,  0.],
+            [ 3.,  0., -4.,  3.]
+        ])
+    ]
+
+    models2 = []
+    for i in range(100):
+        models2.append(torch.rand(1280, 1280))
+
+    expected = torch.tensor([
+        [ 0.6583,  4.5956,  2.5195, -1.1094],
+        [ 3.1552,  1.5443, -2.4330,  2.2136],
+        [ 0.0614,  0.7001,  2.6028,  4.5609],
+        [ 4.1000,  0.1333,  0.2084, -0.3341]
+    ])
+
+    Iso_c, _ = sd_mecha.isotropic.__wrapped__(*models)
+    assert torch.allclose(Iso_c, expected, atol=0.0001)
+
+
+if __name__ == "__main__":
+    test_isotropic()

--- a/tests/merge_methods/test_isotropic.py
+++ b/tests/merge_methods/test_isotropic.py
@@ -24,8 +24,10 @@ def test_isotropic():
     ]
 
     models2 = []
-    for i in range(100):
-        models2.append(torch.rand(1280, 1280))
+    #for i in range(100):
+    #    models2.append(torch.rand(1280, 1280))
+    for i in range(20):
+        models2.append(torch.rand(640, 320, 3, 3))
 
     expected = torch.tensor([
         [ 0.6583,  4.5956,  2.5195, -1.1094],
@@ -34,8 +36,11 @@ def test_isotropic():
         [ 4.1000,  0.1333,  0.2084, -0.3341]
     ])
 
-    Iso_c, _ = sd_mecha.isotropic.__wrapped__(*models)
+    Iso_c = sd_mecha.isotropic.__wrapped__(*models)
     assert torch.allclose(Iso_c, expected, atol=0.0001)
+
+    #s_bar = sd_mecha.isotropic.__wrapped__(*models2, return_sbar=True)
+    #_ = sd_mecha.isotropic_overrided.__wrapped__(models2[0], s_bar)
 
 
 if __name__ == "__main__":

--- a/tests/merge_methods/test_isotropic.py
+++ b/tests/merge_methods/test_isotropic.py
@@ -30,13 +30,17 @@ def test_isotropic():
         models2.append(torch.rand(640, 320, 3, 3))
 
     expected = torch.tensor([
-        [ 0.6583,  4.5956,  2.5195, -1.1094],
-        [ 3.1552,  1.5443, -2.4330,  2.2136],
-        [ 0.0614,  0.7001,  2.6028,  4.5609],
-        [ 4.1000,  0.1333,  0.2084, -0.3341]
+        [ 0.4487,  8.7236,  3.9089, -2.5803],
+        [ 4.0244,  4.1229, -6.7844,  4.3609],
+        [-0.0294,  0.0581,  5.3719,  8.3293],
+        [ 9.0466, -2.2665,  2.8416, -1.7849]
     ])
 
-    Iso_c = sd_mecha.isotropic.__wrapped__(*models)
+    apply_exp_1 = False
+    apply_high_dim_1 = False
+
+    Iso_c = sd_mecha.isotropic.__wrapped__(*models, apply_exp=apply_exp_1, apply_high_dim=apply_high_dim_1)
+    #print(Iso_c)
     assert torch.allclose(Iso_c, expected, atol=0.0001)
 
     #s_bar = sd_mecha.isotropic.__wrapped__(*models2, return_sbar=True)


### PR DESCRIPTION
This is my own version of code to enable "post merge treatment" as a part of [Isotropic Merge](https://arxiv.org/abs/2502.04959), and expand it as [ISO-Z](https://github.com/6DammK9/nai-anime-pure-negative-prompt/blob/main/ch01/isotropic.md#spinoff-iso-z). 

Published model as PoC: [z_cof=2.0](https://civitai.com/models/309514?modelVersionId=2024892), [z_cof=0.8](https://civitai.com/models/1671685?modelVersionId=2024825), 

Btw let me expose @ljleb version for anyone who are interested, as [discord message](https://discord.com/channels/1230387092014501918/1380577444737843372/1380928877576192112)

```py
import torch
from sd_mecha import merge_method, Parameter, Return
from torch import Tensor

@merge_method
def isometric_c(
    *deltas: Parameter(Tensor, "delta"),
) -> Return(Tensor, "delta"):
    if not deltas:
        return 0
    original_shape = deltas[0].shape
    if len(original_shape) < 2:
        return sum(deltas) / len(deltas)
    u, s, vh = torch.linalg.svd(sum(deltas).flatten(start_dim=1), full_matrices=False, driver="gesvd" if deltas[0].is_cuda else None)
    return (s.log().mean().exp() * u @ vh).reshape(original_shape)

@merge_method
def isometric_cts(
    *deltas: Parameter(Tensor, "delta"),
    rank_ratio: Parameter(float, "param") = 0.8,
) -> Return(Tensor, "delta"):
    if not deltas:
        return 0
    original_shape = deltas[0].shape
    if len(original_shape) < 2:
        return sum(deltas) / len(deltas)
    u, s, vh = torch.linalg.svd(sum(deltas).flatten(start_dim=1), full_matrices=False, driver="gesvd" if deltas[0].is_cuda else None)

    t = len(deltas)
    r = len(s)
    k = min(max(round(r * rank_ratio), 0), r)
    sp = (r - k) // t

    u_k = u[..., :k]
    s_k = s[..., :k]
    vh_k = vh[..., :k, :]

    u_cat = [u_k]
    s_cat = [s_k]
    vh_cat = [vh_k]

    for delta in deltas:
        delta = delta.flatten(start_dim=1)
        delta_proj = delta - u_k @ (u_k.mH @ delta)
        u_d, s_d, vh_d = torch.linalg.svd(delta_proj, full_matrices=False, driver="gesvd" if deltas[0].is_cuda else None)

        u_cat.append(u_d[..., :sp])
        s_cat.append(s_d[..., :sp])
        vh_cat.append(vh_d[..., :sp, :])

    u_cat = torch.cat(u_cat, dim=-1)
    s_cat = torch.cat(s_cat, dim=-1)
    vh_cat = torch.cat(vh_cat, dim=-2)

    u_u, s_u, vh_u = torch.linalg.svd(u_cat, full_matrices=False, driver="gesvd" if deltas[0].is_cuda else None)
    u = u_u @ vh_u
    u_vh, s_vh, vh_vh = torch.linalg.svd(vh_cat, full_matrices=False, driver="gesvd" if deltas[0].is_cuda else None)
    vh = u_vh @ vh_vh

    s = s_cat.log().mean(dim=-1).exp()
    return (u * s @ vh).reshape(original_shape)
```

You can replace the `.mean` part to my Z Score function. The `torch.ones_like` part sticks with [paper's original implementation](https://github.com/danielm1405/iso-merging/blob/main/src/utils/iso.py).

```py
    # Workaround for dim > 2
    d_ta = d_ta.flatten(start_dim=1)

    # S_ta will be different from S_bar
    U_ta, S_ta, Vh_ta = torch.linalg.svd(d_ta, full_matrices=False)

    # Can it be any kind of mean?
    S_mean = S_ta.log().mean().exp() if apply_exp else S_ta.mean()

    S_Var = S_ta.var()

    Z_ta = (S_ta - S_mean) / S_Var

    S_z = (Z_ta * z_cof) * S_Var + S_mean

    # Follow paper's implementation
    S_bar = torch.ones_like(S_ta) * S_z

    d_Iso_c = torch.linalg.multi_dot((U_ta, torch.diag(S_bar), Vh_ta)) 
```